### PR TITLE
Add JSON generation examples and modify trait implementation

### DIFF
--- a/examples/generate_json.rs
+++ b/examples/generate_json.rs
@@ -1,0 +1,19 @@
+use secretary::{llm::OpenAILLM, prompt::Prompt, traits::GenerateJSON};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sentiment {
+    sentiment: String,
+}
+
+fn main() {
+    let llm = OpenAILLM::new("your_api_base_url", "your_api_key", "your_model").unwrap();
+    let data_structure = Sentiment {
+        sentiment: String::from("rate the text in terms of their sentiments. it can be: high, low or mid.")
+    };
+    let prompt = Prompt::new(data_structure, vec![]);
+    
+    let result: String = llm.generate_json(&prompt, "This is unacceptable!").unwrap();
+    
+    println!("{}", result);
+}

--- a/examples/generate_json_with_context.rs
+++ b/examples/generate_json_with_context.rs
@@ -1,0 +1,21 @@
+use secretary::{llm::OpenAILLM, prompt::Prompt, traits::GenerateJSON};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sentiment {
+    sentiment: String,
+}
+
+fn main() {
+    let llm = OpenAILLM::new("your_api_base_url", "your_api_key", "your_model").unwrap();
+    let data_structure = Sentiment {
+        sentiment: String::from("rate the text in terms of their sentiments. it can be: high, low or mid.")
+    };
+    let mut prompt = Prompt::new(data_structure, vec![]);
+    // You need to add `async_openai` to assign the role here
+    prompt.push(async_openai::types::Role::User, "This is unacceptable!").unwrap();
+    
+    let result: String = llm.generate_json_with_context(prompt).unwrap();
+    
+    println!("{}", result);
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,13 +20,14 @@ where
     /// # Arguments
     ///
     /// * `prompt` - A string slice that holds the prompt to be sent to the LLM.
+    /// * `target` - A string slice that holds the data to be sent to the LLM to generate a json.
     ///
     /// # Returns
     ///
     /// * `Result<String, Error>` - A result containing the JSON response as a string or an error.
-    fn generate_json(&self, prompt: &Prompt) -> Result<String, Error> {
+    fn generate_json(&self, prompt: &Prompt, target: &str) -> Result<String, Error> {
         let runtime = tokio::runtime::Runtime::new()?;
-        let result = runtime.block_on(
+        let result: String = runtime.block_on(
             async {
                 let request = CreateChatCompletionRequestArgs::default()
                     .model(&self.access_model().to_string())
@@ -34,7 +35,7 @@ where
                     .messages(vec![ChatCompletionRequestUserMessageArgs::default()
                         .content(vec![
                             ChatCompletionRequestMessageContentPartTextArgs::default()
-                                .text(prompt.to_string())
+                                .text(prompt.to_string() + "\nThis is the basis for generating a json:\n" + target)
                                 .build()?
                                 .into(),
                         ])


### PR DESCRIPTION
- Add `generate_json.rs` example demonstrating basic JSON generation
- Add `generate_json_with_context.rs` example showing contextual generation
- Update `GenerateJSON` trait to accept target string parameter
- Modify implementation to include target in prompt construction