### PR TITLE
Implement JSON serialization traits for task types

### DIFF
--- a/examples/contextual_prompt_conversation.rs
+++ b/examples/contextual_prompt_conversation.rs
@@ -174,7 +174,6 @@ fn main() -> Result<()> {
     let mut turn: i32 = 1;
     loop {
         println!("\n--- Turn {} ---", turn);
-        dbg!(&prompt.get_context());
         
         // Generate JSON response from the contextual prompt
         let json_response = llm.generate_json_with_context(&prompt)?;

--- a/src/tasks/basic_task.rs
+++ b/src/tasks/basic_task.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::{
     message_list::{Message, MessageList},
-    traits::{Context, SystemPrompt},
+    traits::{Context, FromJSON, SystemPrompt, ToJSON},
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -107,3 +107,7 @@ impl Context for BasicTask {
         final_context
     }
 }
+
+impl ToJSON for BasicTask {}
+
+impl FromJSON for BasicTask {}

--- a/src/tasks/contextual_task.rs
+++ b/src/tasks/contextual_task.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::{
     message_list::{Message, MessageList, Role},
-    traits::{Context, SystemPrompt},
+    traits::{Context, FromJSON, SystemPrompt, ToJSON},
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -184,3 +184,7 @@ impl Context for ContextualTask {
         Ok(())
     }
 }
+
+impl ToJSON for ContextualTask {}
+
+impl FromJSON for ContextualTask {}


### PR DESCRIPTION

- Add ToJSON and FromJSON trait implementations for BasicTask and ContextualTask
- Remove dbg! output for prompt context in contextual_prompt_conversation example
- Introduce new ToJSON and FromJSON traits with comprehensive documentation for JSON serialization/deserialization capabilities