### PR TITLE
Add force generation support for reasoning models without JSON mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,13 +1076,14 @@ dependencies = [
 
 [[package]]
 name = "secretary"
-version = "0.3.30"
+version = "0.3.40"
 dependencies = [
  "anyhow",
  "async-openai",
  "secretary-derive",
  "serde",
  "serde_json",
+ "surfing",
  "tokio",
 ]
 
@@ -1207,6 +1208,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "surfing"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f279f15aab88e70034c433cf7e88de2d0a55f94ef4172efe94c9d5be690be830"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secretary"
-version = "0.3.30"
+version = "0.3.40"
 edition = "2024"
 description = "Transform natural language into structured data using large language models (LLMs) with powerful derive macros"
 authors =  ["Xinyu Bao <baoxinyuworks@163.com>"]
@@ -18,3 +18,4 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread"] }
 secretary-derive = { path = "secretary-derive", version = "0.3.10" }
+surfing = { version = "0.1.1", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 🔍 **Schema-Based Extraction**: Define your data structure using Rust structs with field-level instructions
 - 📋 **Declarative Field Instructions**: Use `#[task(instruction = "...")]` attributes to guide extraction
 - ⚡ **Async Support**: Built-in async/await support for concurrent processing
+- 🧠 **Reasoning Model Support**: Force generation methods for models without JSON mode (o1, deepseek, etc.)
 - 🔌 **Extensible LLM Support**: Currently supports OpenAI API with more providers planned
 - 🛡️ **Type Safety**: Leverage Rust's type system for reliable data extraction
 - 🧹 **Simplified API**: Consolidated traits reduce boilerplate and complexity
@@ -178,6 +179,20 @@ fn main() -> anyhow::Result<()> {
 }
 ```
 
+### Force Generation for Models Without a JSON Mode
+
+Secretary supports reasoning models like o1 and deepseek that don't have built-in JSON mode support through force generation methods:
+
+```rust
+use secretary::traits::{GenerateData, AsyncGenerateData};
+
+// Synchronous force generation
+let result: PersonInfo = llm.force_generate_data(&task, input, &additional_instructions)?;
+
+// Asynchronous force generation
+let result: PersonInfo = llm.async_force_generate_data(&task, input, &additional_instructions).await?;
+```
+
 ### System Prompt Generation
 
 The derive macro automatically generates comprehensive system prompts:
@@ -201,6 +216,10 @@ The `examples/` directory contains practical demonstrations:
 - **`sync.rs`** - Basic person information extraction using synchronous API
 - **`async.rs`** - Async product information extraction with comprehensive testing
 
+### Force Generation (for Reasoning Models)
+- **`sync_force.rs`** - Financial report extraction using force generation for models without JSON mode
+- **`async_force.rs`** - Research paper extraction using async force generation for reasoning models
+
 Run examples with:
 ```bash
 # Basic synchronous example
@@ -209,10 +228,14 @@ cargo run --example sync
 # Async example with comprehensive testing
 cargo run --example async
 
+# Force generation examples (for o1, deepseek, etc.)
+cargo run --example sync_force
+cargo run --example async_force
+
 # To test with real API, set environment variables:
 export SECRETARY_OPENAI_API_BASE="https://api.openai.com/v1"
 export SECRETARY_OPENAI_API_KEY="your-api-key"
-export SECRETARY_OPENAI_MODEL="gpt-4"
+export SECRETARY_OPENAI_MODEL="gpt-4"  # or "o1-preview", "deepseek-reasoner", etc.
 cargo run --example async
 ```
 
@@ -245,8 +268,8 @@ let llm = OpenAILLM::new(&api_base, &api_key, &model)?;
 | Trait | Purpose | Key Methods |
 |-------|---------|-------------|
 | `Task` | Main trait for data extraction tasks | `new()`, `get_system_prompt()`, `push()` |
-| `GenerateData` | Synchronous LLM interaction | `generate_data()`, `generate_data_with_context()` |
-| `AsyncGenerateData` | Asynchronous LLM interaction | `async_generate_data()`, `async_generate_data_with_context()` |
+| `GenerateData` | Synchronous LLM interaction | `generate_data()`, `force_generate_data()` |
+| `AsyncGenerateData` | Asynchronous LLM interaction | `async_generate_data()`, `async_force_generate_data()` |
 | `IsLLM` | LLM provider abstraction | `access_client()`, `access_model()` |
 | `ToJSON`/`FromJSON` | Serialization utilities | `to_json()`, `from_json()` |
 

--- a/examples/async_force.rs
+++ b/examples/async_force.rs
@@ -1,0 +1,169 @@
+use secretary::llm_providers::openai::OpenAILLM;
+use secretary::traits::AsyncGenerateData;
+use secretary::Task;
+use serde::{Deserialize, Serialize};
+use tokio;
+
+/// Example data structure for extracting research paper information
+/// This example demonstrates force generation for LLMs without JSON mode support
+#[derive(Task, Serialize, Deserialize, Debug, Default)]
+struct ResearchPaperExtraction {
+    /// Research paper data fields with specific extraction instructions
+    #[task(instruction = "Extract the title of the research paper")]
+    pub title: String,
+
+    #[task(instruction = "Extract the main author or first author's name")]
+    pub primary_author: String,
+
+    #[task(instruction = "Extract all co-authors as a comma-separated list")]
+    pub co_authors: Option<String>,
+
+    #[task(instruction = "Extract the publication year as a number")]
+    pub year: u32,
+
+    #[task(instruction = "Extract the journal or conference name")]
+    pub venue: String,
+
+    #[task(instruction = "Extract the abstract or summary of the paper")]
+    pub abstract_text: String,
+
+    #[task(instruction = "Extract key research topics or keywords")]
+    pub keywords: Vec<String>,
+
+    #[task(instruction = "Determine if this is peer-reviewed (true/false)")]
+    pub peer_reviewed: bool,
+}
+
+/// Async force example demonstrating JSON parsing for reasoning models
+/// This example shows how to use async_force_generate_data for models like o1 and deepseek
+/// that don't have built-in JSON mode support but can still generate structured data
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("Secretary Async Force Example - Research Paper Extraction");
+    println!("{}", "=".repeat(65));
+    println!("This example demonstrates force JSON parsing for reasoning models");
+    println!("like o1 and deepseek that don't support native JSON mode.\n");
+
+    // Create a task instance
+    let task = ResearchPaperExtraction::new();
+
+    // Additional instructions for the LLM
+    let additional_instructions = vec![
+        "Extract information accurately even from unstructured text".to_string(),
+        "Use 'Unknown' for missing information".to_string(),
+        "Ensure the output is valid JSON despite model limitations".to_string(),
+        "Focus on the most relevant keywords (max 5)".to_string(),
+    ];
+
+    // Example research paper text (could be from various sources)
+    let paper_text = "
+        Title: Deep Learning Approaches for Natural Language Understanding in Conversational AI
+        
+        Authors: Dr. Sarah Chen (Stanford University), Prof. Michael Rodriguez (MIT), 
+        Dr. Aisha Patel (Google Research), James Wilson (OpenAI)
+        
+        Published: 2024, Journal of Artificial Intelligence Research
+        
+        Abstract: This paper presents novel deep learning architectures for improving 
+        natural language understanding in conversational AI systems. We introduce a 
+        transformer-based approach that combines attention mechanisms with memory networks 
+        to achieve state-of-the-art performance on dialogue understanding tasks. Our method 
+        shows significant improvements over existing baselines on multiple benchmarks, 
+        including a 15% increase in intent classification accuracy and 12% improvement 
+        in entity extraction precision.
+        
+        Keywords: natural language processing, conversational AI, deep learning, 
+        transformer networks, attention mechanisms
+        
+        This work was peer-reviewed and accepted at the top-tier JAIR conference.
+    ";
+
+    println!("Input text:");
+    println!("{}", paper_text);
+    println!();
+
+    // Display the generated system prompt
+    println!("Generated System Prompt:");
+    println!("{}", task.get_system_prompt());
+    println!();
+
+    // Note: This would require actual API credentials to work
+    println!("Setting up async force LLM call (for reasoning models without JSON mode):");
+
+    let llm = OpenAILLM::new(
+        &std::env::var("SECRETARY_OPENAI_API_BASE").unwrap(),
+        &std::env::var("SECRETARY_OPENAI_API_KEY").unwrap(),
+        &std::env::var("SECRETARY_OPENAI_MODEL").unwrap(), // Could be o1-preview, deepseek-reasoner, etc.
+    )?;
+
+    println!("Making async force request to LLM (bypassing JSON mode requirement)...");
+    
+    // Use async_force_generate_data instead of async_generate_data
+    // This method works with reasoning models that don't support JSON mode
+    let result: ResearchPaperExtraction = llm
+        .async_force_generate_data(&task, paper_text, &additional_instructions)
+        .await?;
+        
+    println!("Generated Data Structure: {:#?}", result);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_task_creation() {
+        let task = ResearchPaperExtraction::new();
+        // Task should be created successfully with default values
+        assert_eq!(task.title, "");
+        assert_eq!(task.primary_author, "");
+        assert_eq!(task.co_authors, None);
+        assert_eq!(task.year, 0);
+        assert_eq!(task.venue, "");
+        assert_eq!(task.abstract_text, "");
+        assert!(task.keywords.is_empty());
+        assert_eq!(task.peer_reviewed, false);
+    }
+
+    #[test]
+    fn test_system_prompt_generation() {
+        let task = ResearchPaperExtraction::new();
+        let prompt = task.get_system_prompt();
+
+        // Check that the prompt contains expected elements
+        assert!(prompt.contains("json structure"));
+        assert!(prompt.contains("Field instructions"));
+        assert!(prompt.contains("title"));
+        assert!(prompt.contains("primary_author"));
+        assert!(prompt.contains("year"));
+        assert!(prompt.contains("venue"));
+    }
+
+    #[test]
+    fn test_data_model_instructions() {
+        let data_model = ResearchPaperExtraction::provide_data_model_instructions();
+        
+        // Should provide a default instance for instructions
+        assert_eq!(data_model.title, "");
+        assert_eq!(data_model.year, 0);
+        assert!(data_model.keywords.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_async_force_compatibility() {
+        // Test that our struct works in async context for force generation
+        let task = ResearchPaperExtraction::new();
+
+        // Simulate async operation
+        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+
+        // Task should work in async context
+        assert_eq!(task.title, "");
+        
+        // Verify the task can generate system prompts for force mode
+        let prompt = task.get_system_prompt();
+        assert!(!prompt.is_empty());
+    }
+}

--- a/examples/sync_force.rs
+++ b/examples/sync_force.rs
@@ -1,0 +1,175 @@
+use secretary::llm_providers::openai::OpenAILLM;
+use secretary::traits::GenerateData;
+use secretary::Task;
+use serde::{Deserialize, Serialize};
+
+/// Example data structure for extracting financial report information
+/// This example demonstrates force generation for LLMs without JSON mode support
+#[derive(Task, Serialize, Deserialize, Debug, Default)]
+struct FinancialReportExtraction {
+    /// Financial report data fields with specific extraction instructions
+    #[task(instruction = "Extract the company name")]
+    pub company_name: String,
+
+    #[task(instruction = "Extract the reporting quarter (e.g., Q1, Q2, Q3, Q4)")]
+    pub quarter: String,
+
+    #[task(instruction = "Extract the fiscal year as a number")]
+    pub fiscal_year: u32,
+
+    #[task(instruction = "Extract the total revenue as a number (in millions)")]
+    pub revenue_millions: f64,
+
+    #[task(instruction = "Extract the net income as a number (in millions)")]
+    pub net_income_millions: f64,
+
+    #[task(instruction = "Extract the earnings per share (EPS) as a number")]
+    pub eps: f64,
+
+    #[task(instruction = "Extract key business highlights or achievements")]
+    pub highlights: Vec<String>,
+
+    #[task(instruction = "Determine if the company met analyst expectations (true/false)")]
+    pub met_expectations: bool,
+
+    #[task(instruction = "Extract the CEO or key executive's name if mentioned")]
+    pub ceo_name: Option<String>,
+}
+
+/// Sync force example demonstrating JSON parsing for reasoning models
+/// This example shows how to use force_generate_data for models like o1 and deepseek
+/// that don't have built-in JSON mode support but can still generate structured data
+fn main() -> anyhow::Result<()> {
+    println!("Secretary Sync Force Example - Financial Report Extraction");
+    println!("{}", "=".repeat(62));
+    println!("This example demonstrates force JSON parsing for reasoning models");
+    println!("like o1 and deepseek that don't support native JSON mode.\n");
+
+    // Create a task instance
+    let task = FinancialReportExtraction::new();
+
+    // Additional instructions for the LLM
+    let additional_instructions = vec![
+        "Extract numerical values accurately without currency symbols".to_string(),
+        "Use 'Unknown' for missing information".to_string(),
+        "Ensure the output is valid JSON despite model limitations".to_string(),
+        "Focus on the most significant highlights (max 3)".to_string(),
+    ];
+
+    // Example financial report text
+    let report_text = "
+        APPLE INC. REPORTS FOURTH QUARTER 2024 RESULTS
+        
+        CUPERTINO, California — Apple Inc. (NASDAQ: AAPL) today announced financial 
+        results for its fiscal 2024 fourth quarter ended September 28, 2024.
+        
+        Fourth Quarter 2024 Financial Results:
+        • Total net sales: $94.9 billion, up 6% year-over-year
+        • Net income: $22.9 billion, or $1.46 per diluted share
+        • iPhone revenue: $46.2 billion, up 6% year-over-year
+        • Services revenue: $24.2 billion, up 12% year-over-year
+        
+        \"We are pleased with our strong fourth quarter results, which exceeded 
+        analyst expectations across all major product categories,\" said Tim Cook, 
+        Apple's CEO. \"Our continued innovation in AI and services drove exceptional 
+        growth this quarter.\"
+        
+        Key Highlights:
+        - Record Services revenue of $24.2 billion
+        - Strong iPhone 15 adoption with Pro models leading sales
+        - Successful launch of Apple Intelligence features
+        - Expansion into new international markets
+        
+        The company exceeded Wall Street expectations, with analysts predicting 
+        earnings of $1.40 per share and revenue of $94.5 billion.
+    ";
+
+    println!("Input text:");
+    println!("{}", report_text);
+    println!();
+
+    // Display the generated system prompt
+    println!("Generated System Prompt:");
+    println!("{}", task.get_system_prompt());
+    println!();
+
+    // Note: This would require actual API credentials to work
+    println!("Setting up sync force LLM call (for reasoning models without JSON mode):");
+
+    let llm = OpenAILLM::new(
+        &std::env::var("SECRETARY_OPENAI_API_BASE").unwrap(),
+        &std::env::var("SECRETARY_OPENAI_API_KEY").unwrap(),
+        &std::env::var("SECRETARY_OPENAI_MODEL").unwrap(), // Could be o1-preview, deepseek-reasoner, etc.
+    )?;
+
+    println!("Making sync force request to LLM (bypassing JSON mode requirement)...");
+    
+    // Use force_generate_data instead of generate_data
+    // This method works with reasoning models that don't support JSON mode
+    let result: FinancialReportExtraction = llm
+        .force_generate_data(&task, report_text, &additional_instructions)?;
+        
+    println!("Generated Data Structure: {:#?}", result);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_task_creation() {
+        let task = FinancialReportExtraction::new();
+        // Task should be created successfully with default values
+        assert_eq!(task.company_name, "");
+        assert_eq!(task.quarter, "");
+        assert_eq!(task.fiscal_year, 0);
+        assert_eq!(task.revenue_millions, 0.0);
+        assert_eq!(task.net_income_millions, 0.0);
+        assert_eq!(task.eps, 0.0);
+        assert!(task.highlights.is_empty());
+        assert_eq!(task.met_expectations, false);
+        assert_eq!(task.ceo_name, None);
+    }
+
+    #[test]
+    fn test_system_prompt_generation() {
+        let task = FinancialReportExtraction::new();
+        let prompt = task.get_system_prompt();
+
+        // Check that the prompt contains expected elements
+        assert!(prompt.contains("json structure"));
+        assert!(prompt.contains("Field instructions"));
+        assert!(prompt.contains("company_name"));
+        assert!(prompt.contains("quarter"));
+        assert!(prompt.contains("fiscal_year"));
+        assert!(prompt.contains("revenue_millions"));
+        assert!(prompt.contains("eps"));
+    }
+
+    #[test]
+    fn test_data_model_instructions() {
+        let data_model = FinancialReportExtraction::provide_data_model_instructions();
+        
+        // Should provide a default instance for instructions
+        assert_eq!(data_model.company_name, "");
+        assert_eq!(data_model.fiscal_year, 0);
+        assert_eq!(data_model.revenue_millions, 0.0);
+        assert!(data_model.highlights.is_empty());
+    }
+
+    #[test]
+    fn test_force_generation_compatibility() {
+        // Test that our struct works for force generation scenarios
+        let task = FinancialReportExtraction::new();
+        
+        // Verify the task can generate system prompts for force mode
+        let prompt = task.get_system_prompt();
+        assert!(!prompt.is_empty());
+        
+        // Verify data model instructions work
+        let instructions = FinancialReportExtraction::provide_data_model_instructions();
+        assert_eq!(instructions.company_name, "");
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -122,6 +122,48 @@ where
 
         Ok(serde_json::from_str(&result)?)
     }
+    
+    fn force_generate_data<T: Task>(&self, task: &T, target: &str, additional_instructions: &Vec<String>) -> Result<T, Error> {
+        let formatted_additional_instructions: String = format_additional_instructions(additional_instructions);
+        let runtime: Runtime = tokio::runtime::Runtime::new()?;
+        let result: String = runtime.block_on(async {
+            let request = CreateChatCompletionRequestArgs::default()
+                .model(&self.access_model().to_string())
+                .messages(vec![
+                    ChatCompletionRequestUserMessageArgs::default()
+                        .content(vec![
+                            ChatCompletionRequestMessageContentPartTextArgs::default()
+                                .text(
+                                    task.get_system_prompt()
+                                        + &formatted_additional_instructions
+                                        + "\nThis is the basis for generating a json:\n"
+                                        + target,
+                                )
+                                .build()?
+                                .into(),
+                        ])
+                        .build()?
+                        .into(),
+                ])
+                .build()?;
+
+            let response: CreateChatCompletionResponse =
+                match self.access_client().chat().create(request.clone()).await {
+                    std::result::Result::Ok(response) => response,
+                    Err(e) => {
+                        anyhow::bail!("Failed to execute function: {}", e);
+                    }
+                };
+
+            if let Some(content) = response.choices[0].clone().message.content {
+                return Ok(content);
+            }
+
+            return Err(anyhow!("No response is retrieved from the LLM"));
+        })?;
+
+        Ok(surfing::serde::from_mixed_text(&result)?)
+    }
 }
 
 pub trait AsyncGenerateData
@@ -197,6 +239,43 @@ where
 
         if let Some(content) = response.choices[0].clone().message.content {
             return Ok(serde_json::from_str(&content)?);
+        }
+
+        return Err(anyhow!("No response is retrieved from the LLM"));
+    }
+    
+    async fn async_force_generate_data<T: Task>(&self, task: &T, target: &str, additional_instructions: &Vec<String>) -> Result<T, Error> {
+        let formatted_additional_instructions: String = format_additional_instructions(additional_instructions);
+        let request: CreateChatCompletionRequest = CreateChatCompletionRequestArgs::default()
+            .model(&self.access_model().to_string())
+            .messages(vec![
+                ChatCompletionRequestUserMessageArgs::default()
+                    .content(vec![
+                        ChatCompletionRequestMessageContentPartTextArgs::default()
+                            .text(
+                                task.get_system_prompt()
+                                    + &formatted_additional_instructions
+                                    + "\nThis is the basis for generating a json:\n"
+                                    + target,
+                            )
+                            .build()?
+                            .into(),
+                    ])
+                    .build()?
+                    .into(),
+            ])
+            .build()?;
+
+        let response: CreateChatCompletionResponse =
+            match self.access_client().chat().create(request.clone()).await {
+                std::result::Result::Ok(response) => response,
+                Err(e) => {
+                    anyhow::bail!("Failed to execute function: {}", e);
+                }
+            };
+
+        if let Some(content) = response.choices[0].clone().message.content {
+            return Ok(surfing::serde::from_mixed_text(&content)?);
         }
 
         return Err(anyhow!("No response is retrieved from the LLM"));


### PR DESCRIPTION
- Bump secretary version to 0.3.40
- Add new `surfing` dependency for mixed text JSON parsing
- Implement `force_generate_data` and `async_force_generate_data` methods
- Add examples for sync/async force generation
- Update README with force generation documentation
- Add support for reasoning models like o1 and deepseek